### PR TITLE
Update alerts.html.twig

### DIFF
--- a/templates/components/alerts/alerts.html.twig
+++ b/templates/components/alerts/alerts.html.twig
@@ -31,39 +31,5 @@
         {% block box_title %}{{ tabler_icon('about') }} The "alert" macro{% endblock %}
     {% endembed %}
 
-    {% embed 'components/component_card_demo.html.twig' with {
-        importTpl : "{% from '@Tabler/components/alert.html.twig' import alert %}",
-        fromPathUrl : false,
-        codeTemplates : [
-            "{{ alert('danger', 'Description' ,'Title', 'fas fa-exclamation-triangle', true) }}",
-            "{{ alert('danger', 'Description' ,'Title', 'fas fa-exclamation-triangle') }}",
-            "{{ alert('danger', 'Description' ,'Title', 'fas fa-exclamation-triangle') }}",
-            "{{ alert('warning', 'Description' ,'Title') }}",
-            "{{ alert('warning', null ,'Title') }}",
-            "{{ alert('warning', null ,'Title', 'fas fa-exclamation-triangle') }}",
-            "{{ alert('success', 'Description') }}",
-            "{{ alert('success', 'Description', null, 'fas fa-exclamation-triangle') }}",
-            "{{ alert('primary') }}",
-            "{{ alert('danger', 'description', 'title', 'about') }}",
-            "{{ alert('warning', 'description', 'title', 'fas fa-exclamation', true) }}",
-            "{{ alert('info', 'description', 'What a great bundle') }}",
-            "{{ alert('warning', null, 'title', 'fas fa-exclamation') }}",
-            "{{ alert('warning', null, 'title', 'fas fa-exclamation', true) }}",
-            "{{ alert('danger', null, 'title', 'fas fa-exclamation', true) }}",
-            "{{ alert('warning', 'description', null, 'fas fa-exclamation') }}",
-            "{{ alert('warning', 'description', null, 'fas fa-exclamation', true) }}",
-            "{{ alert('danger', 'description', null, 'fas fa-exclamation') }}",
-            "{{ alert('warning', 'description') }}",
-            "{{ alert('primary', 'description') }}",
-            "{{ alert('success', 'description', null, null, true) }}",
-            "{{ alert('info', null, 'title', null, true) }}",
-        ]
-    } %}
-        {% block box_title %}{{ tabler_icon('about') }} The "alert" macro (deprecated!){% endblock %}
-        {% block box_footer %}
-            <strong>This deprecated way of using it supported passing direct arguments.
-                Will be removed from the API soon: do NOT use it any longer!</strong>
-        {% endblock %}
-    {% endembed %}
 
 {% endblock %}


### PR DESCRIPTION
remove non-working, deprecated examples.  Since they no longer work, there's not much value in displaying them.